### PR TITLE
Fix JobModel migration for updated data column

### DIFF
--- a/Sources/QueuesFluentDriver/JobModelMigrate.swift
+++ b/Sources/QueuesFluentDriver/JobModelMigrate.swift
@@ -14,7 +14,7 @@ public struct JobModelMigrate: Migration {
             .id()
             .field(FieldKey.jobId,     .string, .required)
             .field(FieldKey.queue,     .string, .required)
-            .field(FieldKey.data,      .data,   .required)
+            .field(FieldKey.data,      .json,   .required)
             .field(FieldKey.state,     .string, .required)
             .field(FieldKey.createdAt, .datetime)
             .field(FieldKey.updatedAt, .datetime)


### PR DESCRIPTION
Pull request [#22](https://github.com/m-barthelemy/vapor-queues-fluent-driver/pull/22) forgot to update the migration. As is, all jobs will fail when using the default migration.

Error with Postgres: `server: column "data" is of type bytea but expression is of type jsonb (transformAssignedExpr)`.